### PR TITLE
Fix typo in VARIANT_RADII docstring

### DIFF
--- a/werk24/models/v1/ask.py
+++ b/werk24/models/v1/ask.py
@@ -125,7 +125,7 @@ class W24AskType(str, Enum):
     """
 
     VARIANT_RADII = "VARIANT_RADII"
-    """List of all Radii that were found on teh Sectionals
+    """List of all Radii that were found on the Sectionals
     associated with the variant
     """
 


### PR DESCRIPTION
## Summary
- fix typo in `VARIANT_RADII` docstring

## Testing
- `pytest` *(fails: ServerException: proxy rejected connection: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dbb5ee10c8332bdc5b6bbe6d791b4