### PR TITLE
Use default_factory for exceptions list

### DIFF
--- a/werk24/models/v1/techread.py
+++ b/werk24/models/v1/techread.py
@@ -186,7 +186,7 @@ class W24TechreadBaseResponse(BaseModel):
 
     """
 
-    exceptions: List[W24TechreadException] = []
+    exceptions: List[W24TechreadException] = Field(default_factory=list)
 
     @property
     def is_successful(self) -> bool:


### PR DESCRIPTION
## Summary
- avoid shared mutable list for `exceptions` in `W24TechreadBaseResponse`

## Testing
- `pytest` *(fails: InvalidLicenseException due to missing license; ServerException from proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dbc82c85c83328b6c4ef40f1dee93