### PR TITLE
perf: implement various speedups

### DIFF
--- a/werk24/utils/defaults.py
+++ b/werk24/utils/defaults.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import ClassVar, Set
 
 from packaging.version import Version
 from pydantic import AnyUrl, Field, HttpUrl, field_validator
@@ -61,6 +61,14 @@ class Settings(BaseSettings):
     max_https_retries: int = Field(3, ge=0)
     """Maximum retries for HTTPS requests. Must be greater than or equal to 0."""
 
+    VALID_LOG_LEVELS: ClassVar[Set[str]] = {
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL",
+    }
+
     @field_validator("log_level")
     @classmethod
     def validate_log_level(cls, v: str) -> str:
@@ -69,7 +77,6 @@ class Settings(BaseSettings):
         Ensures that the provided log level is one of the accepted values and
         returns the validated value.
         """
-        valid_log_levels = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
-        if v not in valid_log_levels:
-            raise ValueError(f"log_level must be one of {valid_log_levels}")
+        if v not in cls.VALID_LOG_LEVELS:
+            raise ValueError(f"log_level must be one of {cls.VALID_LOG_LEVELS}")
         return v

--- a/werk24/utils/logger.py
+++ b/werk24/utils/logger.py
@@ -1,6 +1,7 @@
 import logging
 from enum import Enum
-from typing import Optional
+from functools import lru_cache
+from typing import Optional, Union
 
 LOGGER_NAME = "werk24"
 
@@ -13,8 +14,9 @@ class LogLevel(str, Enum):
     CRITICAL = "CRITICAL"
 
 
+@lru_cache(maxsize=None)
 def get_logger(
-    log_level: Optional[LogLevel] = None,
+    log_level: Optional[Union[LogLevel, str]] = None,
     log_format: str = "%(asctime)s - %(name)s [%(levelname)s] %(message)s",
 ) -> logging.Logger:
     """
@@ -35,6 +37,7 @@ def get_logger(
         handler.setFormatter(logging.Formatter(log_format))
         logger.addHandler(handler)
 
-        if log_level is not None:
-            logger.setLevel(log_level.value)  # Use LogLevel directly
+    if log_level is not None:
+        level_value = log_level.value if isinstance(log_level, LogLevel) else log_level
+        logger.setLevel(level_value)
     return logger


### PR DESCRIPTION
## Summary
- reuse a single cryptography backend instance
- cache logger instances and accept string log levels
- avoid re-validating log levels with a class-level set
- pre-expand license search paths and streamline env parsing

## Testing
- `pytest` *(fails: InvalidLicenseException: The provided license is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_689dc1d5327083328b14b7a3ad5e7ffd