### PR TITLE
Add system status endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Unlock manufacturing intelligence from technical drawings with AI.
 [![Tests](https://github.com/W24-Service-GmbH/werk24-python/actions/workflows/python-test.yml/badge.svg)](https://github.com/W24-Service-GmbH/werk24-python/actions/workflows/python-test.yml)
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Why Werk24?](#why-werk24)
 - [Features](#features)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $> werk24 --help
 │ health-check   Run a comprehensive health check for the CLI.                              │
 │ techread       Read a drawing file and extract information.                               │
 │ version        Print the version of the Client.                                           │
+│ status         Fetch and display the Werk24 system status.                               │
 ╰───────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```

--- a/tests/test_cli_status_command.py
+++ b/tests/test_cli_status_command.py
@@ -20,4 +20,4 @@ def test_status_cli(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(status_cmd.app, [])
     assert result.exit_code == 0
-    assert "\"status_indicator\": \"ok\"" in result.stdout
+    assert '"status_indicator": "ok"' in result.stdout

--- a/tests/test_cli_status_command.py
+++ b/tests/test_cli_status_command.py
@@ -1,0 +1,23 @@
+from typer.testing import CliRunner
+
+from werk24 import SystemStatus
+from werk24.cli.commands import status as status_cmd
+
+
+async def mock_get_status():
+    return SystemStatus(
+        page="Werk24",
+        status_indicator="ok",
+        status_description="All systems operational",
+        incidents=[],
+        scheduled_maintenances=[],
+        components=[],
+    )
+
+
+def test_status_cli(monkeypatch):
+    monkeypatch.setattr(status_cmd.Werk24Client, "get_system_status", mock_get_status)
+    runner = CliRunner()
+    result = runner.invoke(status_cmd.app, [])
+    assert result.exit_code == 0
+    assert "\"status_indicator\": \"ok\"" in result.stdout

--- a/tests/test_system_status.py
+++ b/tests/test_system_status.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from werk24 import SystemStatus, Werk24Client
+import aiohttp
+
+
+@pytest.mark.asyncio
+async def test_get_system_status():
+    payload = {
+        "page": "Werk24",
+        "status_indicator": "ok",
+        "status_description": "All systems operational",
+        "incidents": [],
+        "scheduled_maintenances": [],
+        "components": [],
+    }
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = payload
+
+    mock_context = MagicMock()
+    mock_context.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_context.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get = MagicMock(return_value=mock_context)
+
+    with patch.object(aiohttp, "ClientSession", return_value=mock_session):
+        status = await Werk24Client.get_system_status()
+
+    assert isinstance(status, SystemStatus)
+    assert status.status_indicator == "ok"
+    mock_session.get.assert_called_once()

--- a/tests/test_system_status.py
+++ b/tests/test_system_status.py
@@ -1,8 +1,9 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from werk24 import SystemStatus, Werk24Client
 import aiohttp
+import pytest
+
+from werk24 import SystemStatus, Werk24Client
 
 
 @pytest.mark.asyncio

--- a/werk24/cli/commands/health_check.py
+++ b/werk24/cli/commands/health_check.py
@@ -28,6 +28,7 @@ def health_check():
     system_information()
     license_information()
     asyncio.run(network_information())
+    asyncio.run(status_information())
 
 
 def system_information():
@@ -126,6 +127,20 @@ async def network_information():
         )
 
     print_panel("Network Information", network_info)
+
+
+async def status_information():
+    """Display the system status information."""
+    status_info = []
+    try:
+        status = await Werk24Client.get_system_status()
+        status_info.append(("Indicator", status.status_indicator))
+        if status.status_description:
+            status_info.append(("Description", status.status_description))
+    except Exception as e:
+        status_info.append(("Error", f"[red]{type(e).__name__} - {e}[/red]"))
+
+    print_panel("System Status", status_info)
 
 
 def print_panel(title: str, rows: list[tuple[str, str]]) -> None:

--- a/werk24/cli/commands/status.py
+++ b/werk24/cli/commands/status.py
@@ -1,0 +1,17 @@
+import asyncio
+
+import typer
+from rich.console import Console
+
+from werk24.techread import Werk24Client
+
+app = typer.Typer()
+console = Console()
+
+
+@app.command()
+def status():
+    """Fetch and display the Werk24 system status."""
+
+    system_status = asyncio.run(Werk24Client.get_system_status())
+    console.print_json(data=system_status.model_dump())

--- a/werk24/cli/commands/status.py
+++ b/werk24/cli/commands/status.py
@@ -14,4 +14,4 @@ def status():
     """Fetch and display the Werk24 system status."""
 
     system_status = asyncio.run(Werk24Client.get_system_status())
-    console.print_json(data=system_status.model_dump())
+    console.print_json(data=system_status.model_dump(mode="json"))

--- a/werk24/cli/werk24.py
+++ b/werk24/cli/werk24.py
@@ -9,9 +9,9 @@ from ..utils.exceptions import TechreadException
 from ..utils.logger import get_logger
 from .commands.health_check import app as health_check_app
 from .commands.init import app as init_app
+from .commands.status import app as status_app
 from .commands.techread import app as techread_app
 from .commands.version import app as version_app
-from .commands.status import app as status_app
 
 settings = Settings()
 

--- a/werk24/cli/werk24.py
+++ b/werk24/cli/werk24.py
@@ -11,6 +11,7 @@ from .commands.health_check import app as health_check_app
 from .commands.init import app as init_app
 from .commands.techread import app as techread_app
 from .commands.version import app as version_app
+from .commands.status import app as status_app
 
 settings = Settings()
 
@@ -23,6 +24,7 @@ app.add_typer(init_app)
 app.add_typer(health_check_app)
 app.add_typer(techread_app)
 app.add_typer(version_app)
+app.add_typer(status_app)
 
 
 class PromptType(str, Enum):

--- a/werk24/models/v2/__init__.py
+++ b/werk24/models/v2/__init__.py
@@ -3,3 +3,4 @@ from .enums import *  # noqa: F403
 from .internal import *  # noqa: F403
 from .models import *  # noqa: F403
 from .responses import *  # noqa: F403
+from .status import *  # noqa: F403

--- a/werk24/models/v2/status.py
+++ b/werk24/models/v2/status.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "SystemStatus",
+    "SystemStatusComponent",
+    "SystemStatusIncident",
+    "SystemStatusMaintenance",
+]
+
+
+class SystemStatusIncident(BaseModel):
+    """Represents an incident currently affecting the platform."""
+
+    name: str
+    status: str
+    shortlink: Optional[str] = None
+
+
+class SystemStatusMaintenance(BaseModel):
+    """Scheduled maintenance information."""
+
+    name: str
+    status: str
+    scheduled_for: Optional[datetime] = None
+
+
+class SystemStatusComponent(BaseModel):
+    """Status information for a specific API component."""
+
+    id: str
+    name: str
+    status: str
+    updated_at: Optional[datetime] = None
+
+
+class SystemStatus(BaseModel):
+    """Overall system status returned by the status endpoint."""
+
+    page: Optional[str] = None
+    status_indicator: str
+    status_description: Optional[str] = None
+    incidents: List[SystemStatusIncident] = Field(default_factory=list)
+    scheduled_maintenances: List[SystemStatusMaintenance] = Field(
+        default_factory=list
+    )
+    components: List[SystemStatusComponent] = Field(default_factory=list)

--- a/werk24/models/v2/status.py
+++ b/werk24/models/v2/status.py
@@ -45,7 +45,5 @@ class SystemStatus(BaseModel):
     status_indicator: str
     status_description: Optional[str] = None
     incidents: List[SystemStatusIncident] = Field(default_factory=list)
-    scheduled_maintenances: List[SystemStatusMaintenance] = Field(
-        default_factory=list
-    )
+    scheduled_maintenances: List[SystemStatusMaintenance] = Field(default_factory=list)
     components: List[SystemStatusComponent] = Field(default_factory=list)

--- a/werk24/techread.py
+++ b/werk24/techread.py
@@ -20,6 +20,7 @@ from werk24 import (
     EncryptionKeys,
     Hook,
     PresignedPost,
+    SystemStatus,
     TechreadAction,
     TechreadCommand,
     TechreadException,
@@ -30,7 +31,6 @@ from werk24 import (
     TechreadMessageType,
     TechreadRequest,
     TechreadWithCallbackPayload,
-    SystemStatus,
 )
 from werk24._version import __version__
 from werk24.utils.crypt import decrypt_with_private_key, encrypt_with_public_key
@@ -772,8 +772,12 @@ class Werk24Client:
         ssl_context = ssl.create_default_context(cafile=certifi.where())
         connector = aiohttp.TCPConnector(ssl=ssl_context)
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=30)
-        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
-            async with session.get(url, headers={"Accept": "application/json"}) as response:
+        async with aiohttp.ClientSession(
+            timeout=timeout, connector=connector
+        ) as session:
+            async with session.get(
+                url, headers={"Accept": "application/json"}
+            ) as response:
                 Werk24Client._raise_for_status(url, response.status)
                 payload = await response.json()
         return SystemStatus.model_validate(payload)


### PR DESCRIPTION
## Summary
- add SystemStatus models and parsing
- expose system status via client and CLI
- display system status in health check output

## Testing
- `pytest tests/test_system_status.py tests/test_cli_status_command.py -q`
- `pytest -q` *(fails: werk24.utils.exceptions.InvalidLicenseException: The provided license is invalid or has expired)*

------
https://chatgpt.com/codex/tasks/task_e_68a586a16de08332832fb1c2b854e0e3