### PR TITLE
chore: link changelog from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ keywords = [
 homepage = "https://werk24.io"
 repository = "https://github.com/W24-Service-GmbH/werk24-python"
 documentation = "https://werk24.io/docs"
+changelog = "https://github.com/W24-Service-GmbH/werk24-python/releases"
 
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- link changelog in package metadata to GitHub releases for PyPI

## Testing
- `pytest` *(fails: InvalidLicenseException & ServerException)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f45603bc8332b2b43973b343f758