### PR TITLE
feat: allow custom CA bundle

### DIFF
--- a/werk24/cli/commands/status.py
+++ b/werk24/cli/commands/status.py
@@ -10,8 +10,17 @@ console = Console()
 
 
 @app.command()
-def status():
+def status(
+    custom_cafile: str = typer.Option(
+        None, help="Path to an additional CA bundle for TLS verification"
+    )
+):
     """Fetch and display the Werk24 system status."""
 
-    system_status = asyncio.run(Werk24Client.get_system_status())
+    if custom_cafile:
+        system_status = asyncio.run(
+            Werk24Client.get_system_status(custom_cafile=custom_cafile)
+        )
+    else:
+        system_status = asyncio.run(Werk24Client.get_system_status())
     console.print_json(data=system_status.model_dump(mode="json"))

--- a/werk24/cli/commands/techread.py
+++ b/werk24/cli/commands/techread.py
@@ -45,6 +45,9 @@ def techread(
     ),
     ask_sheet_images: bool = typer.Option(False, help="Ask for sheet images"),
     ask_view_images: bool = typer.Option(False, help="Ask for view image"),
+    custom_cafile: str = typer.Option(
+        None, help="Path to an additional CA bundle for TLS verification"
+    ),
 ):
     """Read a drawing file and extract information."""
 
@@ -76,11 +79,13 @@ def techread(
         raise UserInputError("No hooks selected. At least one hook must be enabled.")
 
     with open(file_path, "rb") as fid:
-        asyncio.run(run(server, fid, hooks, max_pages))
+        asyncio.run(run(server, fid, hooks, max_pages, custom_cafile))
 
 
-async def run(server: str, fh: str, hooks: list[Hook], max_pages: int):
-    async with Werk24Client(server) as client:
+async def run(
+    server: str, fh: str, hooks: list[Hook], max_pages: int, custom_cafile: Optional[str]
+):
+    async with Werk24Client(server, custom_cafile=custom_cafile) as client:
         await client.read_drawing_with_hooks(fh, hooks, max_pages)
 
 


### PR DESCRIPTION
## Summary
- allow specifying additional CA bundle via `custom_cafile` in `Werk24Client`
- add `--custom-cafile` option to CLI commands (techread, status, health-check)

## Testing
- `pytest -q` *(fails: proxy rejected connection: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c52c4a6c833283caa3144d694e34