### PR TITLE
test: expand utility coverage and skip client integration tests without license

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 from importlib.resources import files
-
+import os
 import pytest
 from unittest.mock import AsyncMock
 
@@ -14,6 +14,16 @@ from werk24 import (
 from werk24.utils.exceptions import InvalidLicenseException, UnauthorizedException
 
 FILE_PATH = files("werk24") / "assets/DRAWING_SUCCESS.png"
+
+
+# Skip integration tests if no license is available in the environment
+pytestmark = pytest.mark.skipif(
+    not (
+        os.getenv("W24TECHREAD_AUTH_TOKEN")
+        and os.getenv("W24TECHREAD_AUTH_REGION")
+    ),
+    reason="Werk24 license not configured",
+)
 
 
 @pytest.fixture

--- a/tests/test_crypt.py
+++ b/tests/test_crypt.py
@@ -1,0 +1,60 @@
+import io
+
+import pytest
+
+from werk24.utils.crypt import (
+    decrypt_with_private_key,
+    encrypt_with_public_key,
+    generate_new_key_pair,
+)
+
+
+@pytest.fixture
+def key_pair():
+    """Generate a reusable RSA key pair for tests."""
+    return generate_new_key_pair(b"super-secret")
+
+
+def test_generate_new_key_pair_returns_pem(key_pair):
+    private_key, public_key = key_pair
+    assert private_key.startswith(b"-----BEGIN ENCRYPTED PRIVATE KEY-")
+    assert public_key.startswith(b"-----BEGIN PUBLIC KEY-")
+
+
+def test_generate_new_key_pair_invalid_passphrase():
+    with pytest.raises(RuntimeError):
+        generate_new_key_pair("not-bytes")
+
+
+def test_generate_new_key_pair_invalid_key_size():
+    with pytest.raises(RuntimeError):
+        generate_new_key_pair(b"pwd", key_size=1024)
+
+
+def test_encrypt_decrypt_roundtrip_bytes(key_pair):
+    private_key, public_key = key_pair
+    data = b"hello cryptography"
+    encrypted = encrypt_with_public_key(public_key, data)
+    decrypted = decrypt_with_private_key(private_key, "super-secret", encrypted)
+    assert decrypted == data
+
+
+def test_encrypt_with_public_key_accepts_file_like(key_pair):
+    _, public_key = key_pair
+    buffer = io.BytesIO(b"file-like data")
+    encrypted = encrypt_with_public_key(public_key, buffer)
+    assert isinstance(encrypted, bytes)
+
+
+def test_encrypt_with_public_key_invalid_data(key_pair):
+    _, public_key = key_pair
+    with pytest.raises(ValueError):
+        encrypt_with_public_key(public_key, 123)  # type: ignore[arg-type]
+
+
+def test_decrypt_with_private_key_incorrect_password(key_pair):
+    private_key, public_key = key_pair
+    encrypted = encrypt_with_public_key(public_key, b"secret")
+    with pytest.raises(ValueError):
+        decrypt_with_private_key(private_key, "wrong", encrypted)
+

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,35 @@
+import logging
+
+import pytest
+
+from werk24.utils.logger import LOGGER_NAME, LogLevel, get_logger
+
+
+@pytest.fixture(autouse=True)
+def reset_logger():
+    """Ensure a clean logger for each test."""
+    get_logger.cache_clear()
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.handlers.clear()
+    yield
+    logger.handlers.clear()
+    get_logger.cache_clear()
+
+
+def test_get_logger_returns_singleton():
+    logger1 = get_logger(LogLevel.INFO)
+    handlers_before = list(logger1.handlers)
+    logger2 = get_logger(LogLevel.INFO)
+    assert logger1 is logger2
+    assert logger2.handlers == handlers_before
+
+
+def test_get_logger_accepts_enum():
+    logger = get_logger(LogLevel.DEBUG)
+    assert logger.level == logging.DEBUG
+
+
+def test_get_logger_accepts_string():
+    logger = get_logger("ERROR")
+    assert logger.level == logging.ERROR
+


### PR DESCRIPTION
## Summary
- skip client integration tests if Werk24 license variables aren't set
- add unit tests for cryptographic helpers
- add tests for logger configuration and caching

## Testing
- `pip install -r requirements.txt`
- `pip install -r tests/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6bd831e3483328399f8b2701d0398