### PR TITLE
Switch client tests to pytest

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-
 # Test requirements
 pytest==8.3.4
 pytest-asyncio==0.25.3
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,19 +1,36 @@
-from importlib.resources import files
+import os
+import uuid
 
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from werk24 import (
     AskMetaData,
     Hook,
+    TechreadMessage,
     TechreadMessageSubtype,
     TechreadMessageType,
     Werk24Client,
     get_test_drawing,
 )
-from werk24.utils.exceptions import InvalidLicenseException, UnauthorizedException
+from werk24.utils.exceptions import (
+    BadRequestException,
+    InsufficientCreditsException,
+    InvalidLicenseException,
+    RequestTooLargeException,
+    ResourceNotFoundException,
+    ServerException,
+    UnauthorizedException,
+    UnsupportedMediaType,
+)
 
-FILE_PATH = files("werk24") / "assets/DRAWING_SUCCESS.png"
+requires_license = pytest.mark.skipif(
+    not (
+        os.getenv("W24TECHREAD_AUTH_TOKEN")
+        and os.getenv("W24TECHREAD_AUTH_REGION")
+    ),
+    reason="Werk24 license credentials not provided",
+)
 
 
 @pytest.fixture
@@ -21,6 +38,7 @@ def drawing_bytes():
     return get_test_drawing()
 
 
+@requires_license
 @pytest.mark.asyncio
 async def test_read_drawing(drawing_bytes):
     asks = [AskMetaData()]
@@ -49,6 +67,7 @@ async def test_read_drawing(drawing_bytes):
     assert found_completed  # noqa: B101
 
 
+@requires_license
 @pytest.mark.asyncio
 async def test_read_drawing_with_hooks(drawing_bytes):
     hook = AsyncMock()
@@ -63,6 +82,7 @@ async def test_read_drawing_with_hooks(drawing_bytes):
     )
 
 
+@requires_license
 @pytest.mark.asyncio
 async def test_read_drawing_with_callback(
     drawing_bytes, callback_url: str = "https://werk24.io"
@@ -74,6 +94,7 @@ async def test_read_drawing_with_callback(
     assert request_id is not None
 
 
+@requires_license
 @pytest.mark.asyncio
 async def test_invalid_token():
     """
@@ -92,3 +113,94 @@ async def test_invalid_region():
     with pytest.raises(InvalidLicenseException):
         async with Werk24Client(token="", region=None):
             ...
+
+
+def test_run_preflight_checks_invalid_type():
+    with pytest.raises(UnsupportedMediaType):
+        Werk24Client.run_preflight_checks("not-bytes")
+
+
+def test_get_hook_function_for_message_ask():
+    ask = AskMetaData()
+    hook_func = Mock()
+    hook = Hook(ask=ask, function=hook_func)
+    message = TechreadMessage(
+        request_id=uuid.uuid4(),
+        message_type=TechreadMessageType.ASK,
+        message_subtype=ask.ask_type,
+    )
+    result = Werk24Client._get_hook_function_for_message(message, [hook])
+    assert result is hook_func
+
+
+def test_get_hook_function_for_message_no_match():
+    hook = Hook(
+        message_type=TechreadMessageType.PROGRESS,
+        message_subtype=TechreadMessageSubtype.PROGRESS_COMPLETED,
+        function=Mock(),
+    )
+    message = TechreadMessage(
+        request_id=uuid.uuid4(),
+        message_type=TechreadMessageType.PROGRESS,
+        message_subtype=TechreadMessageSubtype.PROGRESS_STARTED,
+    )
+    assert (
+        Werk24Client._get_hook_function_for_message(message, [hook]) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_hooks_for_message_async():
+    client = Werk24Client(token="t", region="r")
+    message = TechreadMessage(
+        request_id=uuid.uuid4(),
+        message_type=TechreadMessageType.PROGRESS,
+        message_subtype=TechreadMessageSubtype.PROGRESS_STARTED,
+    )
+    hook = Hook(
+        message_type=TechreadMessageType.PROGRESS,
+        message_subtype=TechreadMessageSubtype.PROGRESS_STARTED,
+        function=AsyncMock(),
+    )
+    await client.call_hooks_for_message(message, [hook])
+    hook.function.assert_awaited_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_call_hooks_for_message_sync():
+    client = Werk24Client(token="t", region="r")
+    message = TechreadMessage(
+        request_id=uuid.uuid4(),
+        message_type=TechreadMessageType.PROGRESS,
+        message_subtype=TechreadMessageSubtype.PROGRESS_STARTED,
+    )
+    func = Mock()
+    hook = Hook(
+        message_type=TechreadMessageType.PROGRESS,
+        message_subtype=TechreadMessageSubtype.PROGRESS_STARTED,
+        function=func,
+    )
+    await client.call_hooks_for_message(message, [hook])
+    func.assert_called_once_with(message)
+
+
+def test_raise_for_status_ok():
+    Werk24Client._raise_for_status("https://example.com", 200)
+
+
+@pytest.mark.parametrize(
+    "code,exc",
+    [
+        (400, BadRequestException),
+        (401, UnauthorizedException),
+        (404, ResourceNotFoundException),
+        (413, RequestTooLargeException),
+        (415, UnsupportedMediaType),
+        (429, InsufficientCreditsException),
+        (300, ServerException),
+        (500, ServerException),
+    ],
+)
+def test_raise_for_status_raises(code, exc):
+    with pytest.raises(exc):
+        Werk24Client._raise_for_status("https://example.com", code)


### PR DESCRIPTION
## Summary
- Skip client tests requiring Werk24 credentials
- Tidy tests requirements file
- Expand Werk24Client test coverage with preflight, hook, and HTTP status checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70329c8c08332bd302f555e8b5965