### PR TITLE
Add postprocessor slot selection to AskCustom

### DIFF
--- a/tests/test_ask_custom.py
+++ b/tests/test_ask_custom.py
@@ -1,0 +1,19 @@
+import pytest
+
+from werk24 import AskCustom, PostprocessorSlot
+
+
+def test_postprocessor_slot_default_none():
+    ask = AskCustom(custom_id="foo")
+    assert ask.postprocessor_slot is None
+
+
+def test_postprocessor_slot_enum_value():
+    ask = AskCustom(custom_id="foo", postprocessor_slot=PostprocessorSlot.GREEN)
+    assert ask.postprocessor_slot == PostprocessorSlot.GREEN
+
+
+def test_postprocessor_slot_invalid_value():
+    with pytest.raises(ValueError):
+        AskCustom(custom_id="foo", postprocessor_slot="red")
+

--- a/werk24/models/v2/asks.py
+++ b/werk24/models/v2/asks.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field
 
 from werk24.models.v1.ask import W24Ask
-from werk24.models.v2.enums import AskType, ThumbnailFileFormat
+from werk24.models.v2.enums import AskType, ThumbnailFileFormat, PostprocessorSlot
 from werk24.models.v2.models import RedactionKeyword
 
 
@@ -32,12 +32,17 @@ class AskCustom(AskV2):
     ----------
     - custom_id (str): The ID of the custom output to request.
     - config (Dict[str, Any]): Configuration options for the custom output.
+    - postprocessor_slot (Optional[PostprocessorSlot]): The post-processing system to
+      use for this request.
     """
 
     ask_type: Literal[AskType.CUSTOM] = AskType.CUSTOM
     custom_id: str = Field(..., description="The ID of the custom output to request.")
     config: Dict[str, Any] = Field(
         {}, description="Configuration options for the custom output."
+    )
+    postprocessor_slot: Optional[PostprocessorSlot] = Field(
+        None, description="Select which postprocessing system to use."
     )
 
 

--- a/werk24/models/v2/enums.py
+++ b/werk24/models/v2/enums.py
@@ -1394,6 +1394,16 @@ class ThumbnailFileFormat(str, Enum):
     """The output format is PNG."""
 
 
+class PostprocessorSlot(str, Enum):
+    """Enumeration for available postprocessor systems."""
+
+    GREEN = "GREEN"
+    """Use the green postprocessing system."""
+
+    BLUE = "BLUE"
+    """Use the blue postprocessing system."""
+
+
 class PrimaryProcessType(str, Enum):
     CUTTING = "CUTTING"
     TURNING = "TURNING"


### PR DESCRIPTION
## Summary
- add `PostprocessorSlot` enum for available postprocessor systems
- allow `AskCustom` to specify `postprocessor_slot`
- cover new attribute with unit tests

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9808975c483329888659d7a4256b1