### PR TITLE
feat: add configuration incorrect exception

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["wheel", "setuptools"]
 
 [project]
 name = "werk24"
-version = "2.2.0"
+version = "2.3.0"
 description = "AI-powered platform for extracting and analyzing data from technical drawings / CAD drawings to enhance manufacturing workflows."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE.txt" }

--- a/tests/test_exception_types.py
+++ b/tests/test_exception_types.py
@@ -1,0 +1,7 @@
+from werk24.models.v1.techread import W24TechreadExceptionType
+from werk24.models.v2.internal import TechreadExceptionType
+
+
+def test_configuration_incorrect_enum_present():
+    assert TechreadExceptionType.CONFIGURATION_INCORRECT.value == "CONFIGURATION_INCORRECT"
+    assert W24TechreadExceptionType.CONFIGURATION_INCORRECT.value == "CONFIGURATION_INCORRECT"

--- a/werk24/models/v1/techread.py
+++ b/werk24/models/v1/techread.py
@@ -111,6 +111,12 @@ class W24TechreadExceptionType(str, Enum):
     be a drawing
     """
 
+    CONFIGURATION_INCORRECT = "CONFIGURATION_INCORRECT"
+    """ The configuration is incomplete or malformed.
+    Requires client version 2.3.0 or newer. Older clients
+    will receive DRAWING_CONTENT_NOT_UNDERSTOOD instead.
+    """
+
     DRAWING_PAPER_SIZE_TOO_LARGE = "DRAWING_PAPER_SIZE_TOO_LARGE"
     """ The paper size is larger that the allowed paper size
     """

--- a/werk24/models/v2/internal.py
+++ b/werk24/models/v2/internal.py
@@ -123,6 +123,12 @@ class TechreadExceptionType(str, Enum):
     be a drawing
     """
 
+    CONFIGURATION_INCORRECT = "CONFIGURATION_INCORRECT"
+    """ The configuration is incomplete or malformed.
+    Requires client version 2.3.0 or newer. Older clients
+    will receive DRAWING_CONTENT_NOT_UNDERSTOOD instead.
+    """
+
     DRAWING_PAPER_SIZE_TOO_LARGE = "DRAWING_PAPER_SIZE_TOO_LARGE"
     """ The paper size is larger that the allowed paper size
     """


### PR DESCRIPTION
## Summary
- support new CONFIGURATION_INCORRECT error for misconfigured requests
- bump client version to 2.3.0 and document requirement for new error
- cover new enum with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bac9501b588332a6850ec6d4c4c1d3