### PR TITLE
release: 2.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["wheel", "setuptools"]
 
 [project]
 name = "werk24"
-version = "2.4.0"
+version = "2.4.1"
 description = "AI-powered platform for extracting and analyzing data from technical drawings / CAD drawings to enhance manufacturing workflows."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
## Changes

- Bump version to 2.4.1
- Includes `__main__.py` for cross-platform CLI support (merged in #513)

Users can now reliably run `python -m werk24 init` on Windows without PATH issues.