### PR TITLE
Include PNG assets in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ documentation = "https://werk24.io/docs"
 changelog = "https://github.com/W24-Service-GmbH/werk24-python/releases"
 
 
+[tool.setuptools.package-data]
+werk24 = ["assets/*.png"]
+
 [project.scripts]
 werk24 = "werk24.cli.werk24:app"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["wheel", "setuptools"]
 
 [project]
 name = "werk24"
-version = "2.4.1"
+version = "2.4.2"
 description = "AI-powered platform for extracting and analyzing data from technical drawings / CAD drawings to enhance manufacturing workflows."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
## Summary
This change ensures that PNG asset files are included in the distributed Python package by configuring setuptools package data.

## Key Changes
- Added `[tool.setuptools.package-data]` configuration to `pyproject.toml`
- Specified that all PNG files in the `assets/` directory should be included in the `werk24` package distribution

## Implementation Details
The configuration uses setuptools' package-data mechanism to explicitly declare that `*.png` files from the `assets/` directory are data files that should be packaged with the `werk24` module. This ensures these assets are available when the package is installed via pip or other package managers, rather than only being present in the source repository.

https://claude.ai/code/session_01HWtfixTiB4NgTDZA4XLEQ4