### PR TITLE
Bump cryptography minimum version to 46.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ dependencies = [
   # No upper bound - certificate bundle updates are backward compatible
   "certifi>=2024.12.14",
 
-  # cryptography: Minimum 46.0.5 includes fix for CVE-2026-26007 (elliptic curve subgroup validation)
-  # and earlier fixes for CVE-2024-26130 (NULL pointer dereference with pkcs12)
+  # cryptography: Minimum 46.0.7 includes fix for buffer overflow with non-contiguous buffers (GHSA),
+  # plus CVE-2026-26007 (elliptic curve subgroup validation) and CVE-2024-26130 (NULL pointer dereference with pkcs12)
   # No upper bound - follows SemVer, removing restrictive constraint to prevent dependency conflicts
-  "cryptography>=46.0.5",
+  "cryptography>=46.0.7",
 
   # packaging: Minimum 24.2 provides required version parsing functionality
   # No upper bound - stable API, backward compatible

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 
 aiohttp==3.13.4
 certifi==2026.2.25
-cryptography==46.0.6
+cryptography==46.0.7
 packaging==26.0
 pint==0.25.3; python_version > "3.10"
 pint==0.24.4; python_version <= "3.10"


### PR DESCRIPTION
## Summary
Updates the minimum required version of the `cryptography` dependency from 46.0.5 to 46.0.7 to include an additional security fix for buffer overflow vulnerabilities with non-contiguous buffers.

## Changes
- Updated `pyproject.toml` to require `cryptography>=46.0.7`
- Updated `requirements.txt` to pin `cryptography==46.0.7`
- Enhanced dependency documentation to clarify that version 46.0.7 includes:
  - Fix for buffer overflow with non-contiguous buffers (GHSA)
  - CVE-2026-26007 (elliptic curve subgroup validation)
  - CVE-2024-26130 (NULL pointer dereference with pkcs12)

## Details
This change ensures users have access to the latest security patches in the cryptography library. The version constraint maintains the existing policy of no upper bound to follow SemVer and prevent dependency conflicts.

https://claude.ai/code/session_01217vzNmVWH7Ddt8jg7iHtc