### PR TITLE
fix: remove duplicate W24PropertyHardnessRockwellScale definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["wheel", "setuptools"]
 
 [project]
 name = "werk24"
-version = "2.4.3"
+version = "2.4.4"
 description = "AI-powered platform for extracting and analyzing data from technical drawings / CAD drawings to enhance manufacturing workflows."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE.txt" }

--- a/werk24/models/v1/property/hardness.py
+++ b/werk24/models/v1/property/hardness.py
@@ -8,6 +8,8 @@ from ..value import W24PhysicalQuantity, W24Value
 
 
 class W24PropertyHardnessRockwellScale(str, Enum):
+    """List of available Rockwell hardness scales."""
+
     A = "A"
     B = "BW"
     C = "C"
@@ -50,26 +52,6 @@ class W24PropertyHardnessRockwell(W24PropertyHardness):
     hardness_number: W24Value
     hardness_scale: W24PropertyHardnessRockwellScale
     use_sm_indenter_and_holder: bool = False
-
-
-class W24PropertyHardnessRockwellScale(str, Enum):
-    """List of available Rockwell hardness scales."""
-
-    A = "A"
-    B = "BW"
-    C = "C"
-    D = "D"
-    E = "EW"
-    F = "FW"
-    G = "GW"
-    H = "HW"
-    K = "KW"
-    _15N = "15N"
-    _30N = "30N"
-    _45N = "45N"
-    _15T = "15TW"
-    _30T = "30TW"
-    _45T = "45TW"
 
 
 class W24PropertyHardnessLeebScale(str, Enum):


### PR DESCRIPTION
## Problem

`W24PropertyHardnessRockwellScale` was defined **twice** in `werk24/models/v1/property/hardness.py` — once before `W24PropertyHardnessRockwell` and again after it, with byte-for-byte identical members.

Because of this:
- The pydantic field `W24PropertyHardnessRockwell.hardness_scale` bound to the **first** class object (evaluated while the class body ran).
- The module attribute `werk24.models.v1.property.hardness.W24PropertyHardnessRockwellScale` — what `pickle` resolves by qualified name — pointed at the **second**.

So a parsed/constructed `W24PropertyHardnessRockwell` held an enum member whose class could not be found under its own name, and pickling it (e.g. across a `ProcessPoolExecutor`, cache, or Celery boundary) raised:

```
PicklingError: Can't pickle <enum 'W24PropertyHardnessRockwellScale'>: it's not the same object as werk24.models.v1.property.hardness.W24PropertyHardnessRockwellScale
```

This surfaced as a production error in the `core-reader` service (Sentry `CORE-READER-13Z`) when grammar parses run in worker processes return Rockwell hardness results.

## Fix

Collapse the two definitions into a single one placed above `W24PropertyHardnessRockwell` (keeping the version with the `"""List of available Rockwell hardness scales."""` docstring) and delete the second block. Members are byte-for-byte identical, so this is **behavior-preserving** — it only removes the shadowing redefinition.

I also grepped the whole `werk24` package for any other accidental same-file class/enum redefinitions; this was the only one. (`W24PropertyGlasHomogeneity` vs `W24PropertyGlassHomogeneity` in `glass_homogeneity.py` differ by spelling and are distinct classes.)

## Verification

- `python -m py_compile werk24/models/v1/property/hardness.py` ✅
- Identity check: `W24PropertyHardnessRockwell.model_fields["hardness_scale"].annotation is W24PropertyHardnessRockwellScale` → now `True` (was `False`) ✅
- Round-trip pickle of a constructed `W24PropertyHardnessRockwell` succeeds (previously raised `PicklingError`) ✅
- Test suite: 155 passed, 4 skipped. The only failures are pre-existing `InvalidLicenseException` integration tests that require a live API license/token (unrelated to this change). ✅

Once this ships and core-reader bumps the dependency, the temporary shim there becomes a no-op.

https://claude.ai/code/session_01McoehiPCbG2oVA4WukFo3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01McoehiPCbG2oVA4WukFo3Z)_