### PR TITLE
Add DRAWING_PAGE_COUNT_TOO_LARGE exception type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["wheel", "setuptools"]
 
 [project]
 name = "werk24"
-version = "2.5.0"
+version = "2.6.0"
 description = "AI-powered platform for extracting and analyzing data from technical drawings / CAD drawings to enhance manufacturing workflows."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE.txt" }

--- a/tests/test_exception_types.py
+++ b/tests/test_exception_types.py
@@ -1,5 +1,11 @@
+from uuid import uuid4
+
 from werk24.models.v1.techread import W24TechreadExceptionType
-from werk24.models.v2.internal import TechreadExceptionType
+from werk24.models.v2.internal import (
+    TechreadExceptionType,
+    TechreadMessage,
+    TechreadMessageType,
+)
 
 
 def test_configuration_incorrect_enum_present():
@@ -9,4 +15,40 @@ def test_configuration_incorrect_enum_present():
     assert (
         W24TechreadExceptionType.CONFIGURATION_INCORRECT.value
         == "CONFIGURATION_INCORRECT"
+    )
+
+
+def test_drawing_page_count_too_large_enum_present():
+    assert (
+        TechreadExceptionType.DRAWING_PAGE_COUNT_TOO_LARGE.value
+        == "DRAWING_PAGE_COUNT_TOO_LARGE"
+    )
+    assert (
+        W24TechreadExceptionType.DRAWING_PAGE_COUNT_TOO_LARGE.value
+        == "DRAWING_PAGE_COUNT_TOO_LARGE"
+    )
+
+
+def test_message_parses_drawing_page_count_too_large():
+    """A TechreadMessage carrying the new exception_type must parse
+    without raising a pydantic ValidationError.
+    """
+    message = TechreadMessage.model_validate_json(
+        f"""{{
+            "request_id": "{uuid4()}",
+            "message_type": "ERROR",
+            "message_subtype": "COMPLETED",
+            "exceptions": [
+                {{
+                    "exception_level": "ERROR",
+                    "exception_type": "DRAWING_PAGE_COUNT_TOO_LARGE"
+                }}
+            ]
+        }}"""
+    )
+    assert message.message_type == TechreadMessageType.ERROR
+    assert len(message.exceptions) == 1
+    assert (
+        message.exceptions[0].exception_type
+        == TechreadExceptionType.DRAWING_PAGE_COUNT_TOO_LARGE
     )

--- a/werk24/models/v1/techread.py
+++ b/werk24/models/v1/techread.py
@@ -121,6 +121,11 @@ class W24TechreadExceptionType(str, Enum):
     """ The paper size is larger that the allowed paper size
     """
 
+    DRAWING_PAGE_COUNT_TOO_LARGE = "DRAWING_PAGE_COUNT_TOO_LARGE"
+    """ The document has more pages than can be processed for an output
+    that must cover the whole document (e.g. redaction).
+    """
+
     DRAWING_MEASURE_SYSTEM_INCOMPLETE = "DRAWING_MEASURE_SYSTEM_INCOMPLETE"
     """ The file you submitted contains too few measures to be
     manufacturable

--- a/werk24/models/v2/internal.py
+++ b/werk24/models/v2/internal.py
@@ -133,6 +133,11 @@ class TechreadExceptionType(str, Enum):
     """ The paper size is larger that the allowed paper size
     """
 
+    DRAWING_PAGE_COUNT_TOO_LARGE = "DRAWING_PAGE_COUNT_TOO_LARGE"
+    """ The document has more pages than can be processed for an output
+    that must cover the whole document (e.g. redaction).
+    """
+
 
 class TechreadException(BaseModel):
     """


### PR DESCRIPTION
## Summary
This PR adds support for a new exception type `DRAWING_PAGE_COUNT_TOO_LARGE` to handle cases where documents exceed the page count limit for certain output operations.

## Key Changes
- Added `DRAWING_PAGE_COUNT_TOO_LARGE` enum value to both `W24TechreadExceptionType` (v1) and `TechreadExceptionType` (v2) with documentation explaining it applies to outputs that must cover the whole document (e.g., redaction)
- Added comprehensive test coverage including:
  - Enum presence validation for both v1 and v2 models
  - Integration test verifying that `TechreadMessage` correctly parses JSON containing the new exception type without validation errors
- Bumped version from 2.5.0 to 2.6.0

## Implementation Details
The new exception type is consistently defined across both API versions with identical documentation. The test suite validates both the enum definition and the end-to-end parsing behavior through Pydantic's `model_validate_json`, ensuring the exception type integrates properly with the existing message handling infrastructure.

https://claude.ai/code/session_01M562dp6QvASsxKrmHcQv8A