### PR TITLE
feat: support Bearer token authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["wheel", "setuptools"]
 
 [project]
 name = "werk24"
-version = "2.6.0"
+version = "2.7.0"
 description = "AI-powered platform for extracting and analyzing data from technical drawings / CAD drawings to enhance manufacturing workflows."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE.txt" }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -121,6 +121,43 @@ async def test_token_only_license():
     assert client.license.region is None  # nosec
 
 
+def test_bearer_token_sets_bearer_auth_header():
+    """
+    A client created with a bearer token authenticates with the Bearer scheme
+    and does not require a license.
+    """
+    client = Werk24Client(bearer_token="an-access-token")
+    assert client.license is None  # nosec
+    assert client._get_auth_headers() == {  # nosec
+        "Authorization": "Bearer an-access-token"
+    }
+
+
+def test_bearer_token_does_not_trigger_license_lookup(monkeypatch):
+    """
+    Supplying a bearer token must not fall back to license-file / env lookup,
+    even when no license is available in the environment.
+    """
+    import werk24.techread as techread_module
+
+    def _fail_find_license(*args, **kwargs):
+        raise AssertionError("find_license must not be called in bearer mode")
+
+    monkeypatch.setattr(techread_module, "find_license", _fail_find_license)
+    client = Werk24Client(bearer_token="an-access-token")
+    assert client.license is None  # nosec
+
+
+def test_default_uses_token_scheme():
+    """
+    Without a bearer token the client keeps the license-based Token scheme.
+    """
+    client = Werk24Client(token="some-token")
+    assert client._get_auth_headers() == {  # nosec
+        "Authorization": "Token some-token"
+    }
+
+
 def test_run_preflight_checks_invalid_type():
     with pytest.raises(UnsupportedMediaType):
         Werk24Client.run_preflight_checks("not-bytes")

--- a/werk24/techread.py
+++ b/werk24/techread.py
@@ -111,8 +111,17 @@ class Werk24Client:
         ping_timeout: float = 10.0,
         max_reconnect_attempts: int = 3,
         reconnect_delay: float = 1.0,
+        bearer_token: Optional[str] = None,
     ):
-        self.license = find_license(token, region)
+        # Authentication:
+        # - Static license token (default): the "Token <token>" scheme, resolved
+        #   from the argument, a license file, or the environment.
+        # - Bearer token: an externally issued OIDC/OAuth2 access token (e.g. an
+        #   AWS Cognito access token) forwarded on behalf of an end user. When a
+        #   bearer token is supplied no license is required, since the caller is
+        #   authenticated through the identity provider rather than a license.
+        self._bearer_token = bearer_token
+        self.license = None if bearer_token else find_license(token, region)
         self._wss_server = str(wss_server)
         self._https_server = str(https_server)
         self._wss_session = None
@@ -207,10 +216,15 @@ class Werk24Client:
         """
         Get the authentication headers for the request.
 
+        Uses the ``Bearer`` scheme when an externally issued access token was
+        supplied, otherwise falls back to the license-based ``Token`` scheme.
+
         Returns:
         -------
         - dict: The authentication headers.
         """
+        if self._bearer_token:
+            return {"Authorization": f"Bearer {self._bearer_token}"}
         return {"Authorization": f"Token {self.license.token}"}
 
     def _create_websocket_session(


### PR DESCRIPTION
## Summary

Adds a `bearer_token` auth mode to `Werk24Client` so the client can authenticate with an externally issued OIDC/OAuth2 access token (e.g. an AWS Cognito access token) instead of a static license token. This is the foundation for **per-user authentication** in the new Werk24 MCP server: the MCP server forwards each user's validated access token to the Werk24 API as a `Bearer` credential.

## Changes

- `Werk24Client.__init__` accepts an optional `bearer_token`. When set, no license is required and `_get_auth_headers()` sends `Authorization: Bearer <token>` instead of `Token <license>`.
- Default license/`Token` behavior is unchanged (fully backward compatible).
- Version bump `2.6.0 → 2.7.0`.

## Testing

- New unit tests: Bearer header is set correctly, license lookup is skipped in Bearer mode, and the default path still uses the `Token` scheme. `5/5` auth tests pass.

## Notes

This is the first of four coordinated PRs for the MCP server / OAuth work (werk24-python → crew-api → infrastructure → werk24-mcp). **Publish 2.7.0 to PyPI after merge** — the werk24-mcp Lambda build resolves `werk24 >= 2.7.0` from PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjMtCLBi4BjQb8gp8zGAXy)_